### PR TITLE
Text Kludge and namespaces

### DIFF
--- a/lib/libxml-to-js.js
+++ b/lib/libxml-to-js.js
@@ -21,6 +21,15 @@ var merge = function (obj1, obj2) {
 	return obj3;
 };
 
+function isEmpty(obj) {
+	for(var prop in obj) {
+		if(obj.hasOwnProperty(prop))
+			return false;
+	}
+	return true;
+}
+
+
 /**
  * The core function of this module
  * @param obj
@@ -51,7 +60,7 @@ var libxml2js = function (obj, recurse, namespaces) {
 	
 	for (var i = 0, chlen = children.length; i < chlen; i++) {
 		// <"text" kludge>
-		if (children[i].name() == 'text') {
+		if (children[i].name() == 'text'&&children[i].type() == 'text') {
 			jsobj['#'] = children[i].text().trim();
 			if (jsobj['#'].match(/^\s*$/)) {
 				delete(jsobj['#']);
@@ -114,7 +123,7 @@ var libxml2js = function (obj, recurse, namespaces) {
 	}
 	
 	if ( ! recurse) {
-		if (namespaces) {
+		if (namespaces&&!isEmpty(namespaces)) {
 			if ( ! jsobj['@']) {
 				jsobj['@'] = {};
 			}
@@ -146,6 +155,7 @@ module.exports = function (xml, xpath, callback) {
 		}
 		callback(null, jsDocument);
 	} catch (err) {
+	  console.dir(err);
 		err.message = err.message || 'libxml error';
 		var errInst = new Error(err.message);
 		errInst.code = err.code || 0;

--- a/tests/data/text.xml
+++ b/tests/data/text.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<nouvelle>
+  <news>
+    <auteur>Bizzard5</auteur>
+    <date>17 Août 2008</date>
+    <text></text>
+  </news>
+  <news>
+    <auteur>Little</auteur>
+    <date>18 Août 2007</date>
+    <text><test>test</test></text>
+  </news>
+  <news>
+    <auteur>Bizzard5</auteur>
+    <date>17 Août 2008</date>
+    <text>C'est un teste</text>
+  </news>
+  <news>
+    <auteur>Little</auteur>
+    <date>18 Août 2007</date>
+    <text>Allo</text>
+  </news>
+  <news>
+    <auteur>Little</auteur>
+    <date>18 Août 2007</date>
+    <text><text>test</text></text>
+  </news>
+</nouvelle>
+

--- a/tests/testText.js
+++ b/tests/testText.js
@@ -1,0 +1,12 @@
+var parser = require('../'), util = require('util');
+
+var fs = require('fs');
+var assert = require('assert');
+
+parser(fs.readFileSync('data/text.xml').toString(), function (err, res) {
+	assert.ifError(err);
+	console.log(util.inspect(res, true, null));
+	assert.deepEqual({ 'news':[{ "auteur" : "Bizzard5", "date" : "17 Août 2008", "text" : { }},{ "auteur" : "Little", "date" : "18 Août 2007", "text" : { "test" : "test" }},{ "auteur" : "Bizzard5", "date" : "17 Août 2008", "text" : "C'est un teste"},{ "auteur" : "Little", "date" : "18 Août 2007", "text" : "Allo" },{ "auteur" : "Little", "date" : "18 Août 2007", "text" : { "text" : "test" } }]},
+          res);
+});
+


### PR DESCRIPTION
Two little modifications I hope you'll agree with:
First, to avoid a resulting object of:   "text" : { "#" : "Allooo" } when a tag is named "text".

the second is to avoid adding the namespace subobject in the resulting object when the namespace is the empty object.

I added a full test.
